### PR TITLE
Use no-sign-request flag when downloading from S3.

### DIFF
--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -284,7 +284,7 @@ def smart_ls(pdir, missing_ok=True, memory=None):
                 s3_dir = pdir
                 if not s3_dir.endswith("/"):
                     s3_dir += "/"
-                output = backtick(["aws", "s3", "ls", s3_dir])
+                output = backtick(["aws", "s3", "ls", '--no-sign-request', s3_dir])
                 rows = output.strip().split('\n')
                 result = [r.split()[-1] for r in rows]
             else:

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -104,7 +104,7 @@ class InputStream:
             path = smart_glob(path, expected=1)[0]
         cat = 'set -o pipefail; '
         if path.startswith("s3://"):
-            cat += f"aws s3 --quiet cp {path} -"
+            cat += f"aws s3 --quiet cp --no-sign-request {path} -"
         else:
             cat += f"cat {path}"
         if path.endswith(".lz4"):
@@ -639,7 +639,7 @@ def download_reference(ref_path, local_dir="."):
     if not os.path.exists(local_dir):
         command(f"mkdir -p {local_dir}")
     try:
-        command(f"set -o pipefail; aws s3 cp --only-show-errors {ref_path} - | {uncompress_cmd} > {local_path}")
+        command(f"set -o pipefail; aws s3 cp --only-show-errors --no-sign-request {ref_path} - | {uncompress_cmd} > {local_path}")
     except:
         command(f"rm -f {local_path}")
         raise

--- a/iggtools/subcommands/annotate_genes.py
+++ b/iggtools/subcommands/annotate_genes.py
@@ -27,7 +27,7 @@ def unified_genome_id(genome_id):
 @retry
 def download_genome(genome_id, cleaned_genome):
     command(f"rm -f {genome_id}.fasta")
-    command(f"aws s3 cp --only-show-errors {cleaned_genome} - | lz4 -dc > {genome_id}.fasta")
+    command(f"aws s3 cp --only-show-errors --no-sign-request {cleaned_genome} - | lz4 -dc > {genome_id}.fasta")
 
 
 def annotate_genome(genome_id, species_id):

--- a/iggtools/subcommands/build_pangenome.py
+++ b/iggtools/subcommands/build_pangenome.py
@@ -178,7 +178,7 @@ def build_pangenome_master(args):
     # This will be read separately by each species build subcommand, so we make a local copy.
     local_toc = os.path.basename(outputs.genomes)
     command(f"rm -f {local_toc}")
-    command(f"aws s3 cp --only-show-errors {outputs.genomes} {local_toc}")
+    command(f"aws s3 cp --only-show-errors --no-sign-request {outputs.genomes} {local_toc}")
 
     db = UHGG(local_toc)
     species = db.species

--- a/iggtools/subcommands/import_uhgg.py
+++ b/iggtools/subcommands/import_uhgg.py
@@ -87,7 +87,7 @@ def import_uhgg_master(args):
     # This will be read separately by each species build subcommand, so we make a local copy.
     local_toc = os.path.basename(outputs.genomes)
     command(f"rm -f {local_toc}")
-    command(f"aws s3 cp --only-show-errors {outputs.genomes} {local_toc}")
+    command(f"aws s3 cp --only-show-errors --no-sign-request {outputs.genomes} {local_toc}")
 
     db = UHGG(local_toc)
     species_for_genome = db.genomes


### PR DESCRIPTION
Added `--no-sign-request` flag to several obvious cases of `aws s3 cp` where I believe they're only used for downloading from s3 to local.

As long as the reference data bucket is public, this should enable usage of `iggtools midas_run_species` and other subcommands on local servers without any AWS credentials at all.