### PR TITLE
Add user accessible threads parameter to midas_run subcommands.

### DIFF
--- a/iggtools/common/bowtie2.py
+++ b/iggtools/common/bowtie2.py
@@ -48,11 +48,11 @@ def bowtie2_align(args, bt2_db_dir, bt2_db_name, sort_aln=False, threads=1):
         bt2_command = f"bowtie2 --no-unal -x {bt2_db_dir}/{bt2_db_name} {max_reads} --{aln_mode} --{aln_speed} --threads {threads} -q {r1} {r2}"
         if sort_aln:
             command(f"set -o pipefail; {bt2_command} | \
-                    samtools view --threads {threads} -b - | \
-                    samtools sort --threads {threads} -o {bt2_db_dir}/{bt2_db_name}.bam")
+                    samtools view -@ {threads} -b - | \
+                    samtools sort -@ {threads} -o {bt2_db_dir}/{bt2_db_name}.bam")
         else:
             command(f"set -o pipefail; {bt2_command} | \
-                    samtools view --threads {threads} -b - > {bt2_db_dir}/{bt2_db_name}.bam")
+                    samtools view -@ {threads} -b - > {bt2_db_dir}/{bt2_db_name}.bam")
     except:
         tsprint(f"Bowtie2 align to {bt2_db_dir}/{bt2_db_name}.bam run into error")
         command(f"rm -f {bt2_db_dir}/{bt2_db_name}.bam")

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -93,7 +93,7 @@ def register_args(main_func):
                            default=False,
                            help='FASTA/FASTQ file in -1 are paired and contain forward AND reverse reads')
     subparser.add_argument('--threads',
-                           default=num_physical_cores,
+                           default=num_physical_cores, type=int,
                            help=f"Number of threads used by subprocesses (e.g. bowtie2-build, bowtie2, samtools view), default {num_physical_cores}")
 
 

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -276,7 +276,7 @@ def midas_run_genes(args):
             return download_reference(pangenome_file(species_id, "centroids.ffn.lz4"), f"{tempdir}/{species_id}")  # TODO colocate samples to overlap reference downloads
 
         # Download centroids.ffn for every species in the restricted species profile.
-        centroids_files = multithreading_hashmap(download_centroid, species_profile.keys(), num_threads=args.threads)
+        centroids_files = multithreading_hashmap(download_centroid, species_profile.keys(), num_threads=20)
 
         # Perhaps avoid this giant conglomerated file, fetching instead submaps for each species.
         # Also colocate/cache/download in master for multiple slave subcommand invocations.

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -6,7 +6,7 @@ import Bio.SeqIO
 from pysam import AlignmentFile  # pylint: disable=no-name-in-module
 
 from iggtools.common.argparser import add_subcommand
-from iggtools.common.utils import tsprint, command, InputStream, OutputStream, select_from_tsv, multithreading_hashmap, download_reference
+from iggtools.common.utils import tsprint, command, InputStream, OutputStream, select_from_tsv, multithreading_hashmap, download_reference, num_physical_cores
 from iggtools.params import outputs
 from iggtools.common.samples import parse_species_profile, select_species
 from iggtools.common.bowtie2 import build_bowtie2_db, bowtie2_align

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -305,7 +305,8 @@ def midas_run_snps(args):
             return download_reference(imported_genome_file(representatives[species_id], species_id, "fna.lz4"), f"{tempdir}/{species_id}")
 
         # Download repgenome_id.fna for every species in the restricted species profile.
-        contigs_files = multithreading_hashmap(download_contigs, species_profile.keys(), num_threads=args.threads)
+        # Since this is *not* CPU bound, we use 20 threads.
+        contigs_files = multithreading_hashmap(download_contigs, species_profile.keys(), num_threads=20)
 
         # Use Bowtie2 to map reads to a representative genomes
         bt2_db_name = "repgenomes"

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -50,7 +50,7 @@ def register_args(main_func):
                            default=DEFAULT_SPECIES_COVERAGE,
                            help=f"Include species with >X coverage ({DEFAULT_SPECIES_COVERAGE})")
     subparser.add_argument('--threads',
-                           default=num_physical_cores,
+                           default=num_physical_cores, type=int,
                            help=f"Number of threads used by subprocesses (e.g. hs-blastn), default {num_physical_cores}")
     if False:
         # This is unused.

--- a/iggtools/subcommands/midas_run_species.py
+++ b/iggtools/subcommands/midas_run_species.py
@@ -50,7 +50,7 @@ def register_args(main_func):
                            metavar="INT",
                            help=f"Number of reads to use from input file(s).  (All)")
     subparser.add_argument('--threads',
-                           default=num_physical_cores,
+                           default=num_physical_cores, type=int,
                            help=f"Number of threads used by subprocesses (e.g. hs-blastn), default {num_physical_cores}")
     if False:
         # This is not currently in use.

--- a/iggtools/subcommands/midas_run_species.py
+++ b/iggtools/subcommands/midas_run_species.py
@@ -270,7 +270,7 @@ def midas_run_species(args):
     command(f"rm -rf {tempdir}")
     command(f"mkdir -p {tempdir}")
 
-    markers_db_files = multithreading_map(download_reference, [f"s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.fa{ext}.lz4" for ext in ["", ".bwt", ".header", ".sa", ".sequence"]] + ["s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.map.lz4"])
+    markers_db_files = multithreading_map(download_reference, [f"s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.fa{ext}.lz4" for ext in ["", ".bwt", ".header", ".sa", ".sequence"]] + ["s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.map.lz4"], num_threads=20)
 
     db = UHGG()
     species_info = db.species


### PR DESCRIPTION
Take a `--threads` option for midas_run_species and midas_run_genes subcommands with a default of `num_physical_cores`.