### PR TITLE
Accept prefiltered MIDAS species list to midas_run_snps and midas_run_genes.

### DIFF
--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -293,6 +293,9 @@ def write_snps_summary(species_pileup_stats, outfile):
 
 def midas_run_snps(args):
 
+    if args.species is not None:
+        args.species_cov = 'X'
+
     tempdir = f"{args.outdir}/snps/temp_sc{args.species_cov}"
     if args.debug and os.path.exists(tempdir):
         tsprint(f"INFO:  Reusing existing temp data in {tempdir} according to --debug flag.")

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -149,7 +149,8 @@ def dump_species_list(species, tempdir):
 
 
 def load_species_list(path):
-    return [species_id for species_id in InputStream(path)]
+    with InputStream(path) as file:
+        return [species_id.strip() for species_id in file]
 
 
 def keep_read_worker(aln, args, aln_stats):


### PR DESCRIPTION
Add a command-line option to accept a user-specified species list (one MIDAS species_id per line) that bypasses the coverage filtering apparatus.

This same feature could also be added to midas_run_genes.