### PR TITLE
Enable prebuilt bt2 db for midas_run_snps

### DIFF
--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -295,7 +295,7 @@ def midas_run_genes(args):
     else:
         species_list_path = args.species
         if args.prebuilt_index:
-            for suffix in ['1.bt2', '2.bt2', '3.bt2', '4.bt2', 'rev.1.bt2', 'rev.2.bt2', 'fa']:  # FIXME: Make sure LARGE index looks like this.
+            for suffix in ['1.bt2l', '2.bt2l', '3.bt2l', '4.bt2l', 'rev.1.bt2l', 'rev.2.bt2l', 'fa']:
                 command(f"ln -rs {args.prebuilt_index}.{suffix} {tempdir}/{bt2_db_name}.{suffix}")
 
     try:

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -52,7 +52,7 @@ def register_args(main_func):
     subparser.add_argument('--species',
                            help=("File listing set of species IDs to search "
                                  "against. When set, species_cov is ignored."))
-    subparser.add_arugment('--prebuilt-index',
+    subparser.add_argument('--prebuilt-index',
                            help=("Prebuilt species index.  The --species flag"
                                  "must be set and the index *must match* the "
                                  "list given."))

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -293,6 +293,9 @@ def write_snps_summary(species_pileup_stats, outfile):
 
 def midas_run_snps(args):
 
+    if args.species is not None:
+        args.species_cov = 'X'
+
     tempdir = f"{args.outdir}/snps/temp_sc{args.species_cov}"
     if args.debug and os.path.exists(tempdir):
         tsprint(f"INFO:  Reusing existing temp data in {tempdir} according to --debug flag.")

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -149,7 +149,8 @@ def dump_species_list(species, tempdir):
 
 
 def load_species_list(path):
-    return [species_id for species_id in InputStream(path)]
+    with InputStream(path) as file:
+        return [species_id.strip() for species_id in file]
 
 
 def keep_read_worker(aln, args, aln_stats):


### PR DESCRIPTION
This patch, which includes the changes from #37, allows previously built bowtie2 index files (i.e. `repgenomes.*.bt2`) to be passed to the command, eliminating the need to build a brand new repgenomes database (using `bowtie2-build`) every time.

This can easily save 10s of minutes of CPU time in a relatively normal run.