### PR TITLE
Handle 0 gene hits case while counting up BAM results for a species

### DIFF
--- a/midas2/subcommands/run_genes.py
+++ b/midas2/subcommands/run_genes.py
@@ -517,16 +517,15 @@ def run_genes(args):
 
 
         total_c99_counts = len(readonly_bamgenes)
-        number_of_chunks = args.num_cores
-        chunk_size = ceil(total_c99_counts / number_of_chunks)
-
         args_list = []
-        chunk_id = 0
-        for chunk_start in range(0, total_c99_counts, chunk_size):
-            chunk_end = chunk_start + chunk_size
-            headerless_sliced_path = sample.get_target_layout("chunk_depth", "", chunk_id)
-            args_list.append((chunk_id, chunk_start, chunk_end, pangenome_bamfile, headerless_sliced_path, args.cluster_level))
-            chunk_id += 1
+        number_of_chunks = args.num_cores
+
+        if total_c99_counts:
+            chunk_size = ceil(total_c99_counts / number_of_chunks)
+            for chunk_id, chunk_start in enumerate(range(0, total_c99_counts, chunk_size)):
+                chunk_end = chunk_start + chunk_size
+                headerless_sliced_path = sample.get_target_layout("chunk_depth", "", chunk_id)
+                args_list.append((chunk_id, chunk_start, chunk_end, pangenome_bamfile, headerless_sliced_path, args.cluster_level))
 
         list_of_chunks_depth = multiprocessing_map(compute_pileup_per_chunk, args_list, number_of_chunks)
         dict_of_gene_depth = merge_depth_across_chunks(list_of_chunks_depth, args.cluster_level)


### PR DESCRIPTION
Get the following error on one sample:

```
$ midas2 run_genes --num_cores 1                 -1 data/reads/SS01011/r1.proc.fq.gz -2 data/reads/SS01011/r2.proc.fq.gz                 --sample_name SS01011                 --midasdb_name newdb                 --midasdb_dir ref/midasdb_uhgg_v20_all                 --prebuilt_bowtie2_indexes data/hash/488c8e0d5184748bf52bc26613bba9a5/pangenomes99_v20.bt2.d/pangenomes                 --prebuilt_bowtie2_species data/hash/488c8e0d5184748bf52bc26613bba9a5/species.list                 --species_list 100003                 --skip_species_summary                 --select_threshold=-1                 --aln_speed sensitive                 --aln_extra_flags '--mm --ignore-quals'                 --total_depth 0                 --cluster_level 75                 --debug                 data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d
1709780149.7:  Single sample pan-gene copy number variant calling in subcommand run_genes with args
1709780149.7:  {
1709780149.7:      "subcommand": "run_genes",
1709780149.7:      "force": false,
1709780149.7:      "debug": true,
1709780149.7:      "zzz_worker_mode": false,
1709780149.7:      "batch_branch": "master",
1709780149.7:      "batch_memory": 378880,
1709780149.7:      "batch_vcpus": 48,
1709780149.7:      "batch_queue": "pairani",
1709780149.7:      "batch_ecr_image": "pairani:latest",
1709780149.7:      "midas_outdir": "data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d",
1709780149.7:      "sample_name": "SS01011",
1709780149.7:      "r1": "data/reads/SS01011/r1.proc.fq.gz",
1709780149.7:      "r2": "data/reads/SS01011/r2.proc.fq.gz",
1709780149.7:      "prebuilt_bowtie2_indexes": "data/hash/488c8e0d5184748bf52bc26613bba9a5/pangenomes99_v20.bt2.d/pangenomes",
1709780149.7:      "prebuilt_bowtie2_species": "data/hash/488c8e0d5184748bf52bc26613bba9a5/species.list",
1709780149.7:      "midasdb_name": "newdb",
1709780149.7:      "midasdb_dir": "ref/midasdb_uhgg_v20_all",
1709780149.7:      "species_list": "100003",
1709780149.7:      "select_by": "median_marker_depth",
1709780149.7:      "select_threshold": "-1",
1709780149.7:      "aln_speed": "sensitive",
1709780149.7:      "aln_mode": "global",
1709780149.7:      "aln_interleaved": false,
1709780149.7:      "fragment_length": 500,
1709780149.7:      "max_reads": null,
1709780149.7:      "aln_extra_flags": "--mm --ignore-quals",
1709780149.7:      "aln_mapid": 94.0,
1709780149.7:      "aln_mapq": 0,
1709780149.7:      "aln_readq": 20,
1709780149.7:      "aln_cov": 0.75,
1709780149.7:      "total_depth": 0,
1709780149.7:      "num_cores": 1,
1709780149.7:      "prune_centroids": false,
1709780149.7:      "prune_method": "max",
1709780149.7:      "prune_cutoff": 0.4,
1709780149.7:      "remove_singleton": false,
1709780149.7:      "alignment_only": false,
1709780149.7:      "cluster_level": "75",
1709780149.7:      "remove_bam": false,
1709780149.7:      "remove_bt2_index": false,
1709780149.7:      "skip_species_summary": true
1709780149.7:  }
1709780149.7:  Create OUTPUT directory for SS01011.
1709780149.7:  Use existing data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d/SS01011/genes according to --debug flag.
1709780149.7:  Create TEMP directory for SS01011.
1709780149.7:  Use existing data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d/SS01011/temp/genes according to --debug flag.
1709780149.7:  Use existing large Bowtie2 indexes data/hash/488c8e0d5184748bf52bc26613bba9a5/pangenomes99_v20.bt2.d/pangenomes
1709780149.7:  Read in list of species used to build provided bowtie2 indexes data/hash/488c8e0d5184748bf52bc26613bba9a5/pangenomes99_v20.bt2.d/pangenomes
1709780149.8:  1
1709780150.4:  Use existing large Bowtie2 indexes data/hash/488c8e0d5184748bf52bc26613bba9a5/pangenomes99_v20.bt2.d/pangenomes
1709780150.4:  MIDAS2::build_bowtie2db::finish
1709780150.4:  MIDAS2::bowtie2_align::start
1709780150.4:  Use existing bamfile data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d/SS01011/genes/SS01011.bam
1709780150.4:  Skipping samtools index in debug mode as temporary data exists: data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d/SS01011/genes/SS01011.bam.bai
1709780150.4:  Skipping samtools idxstats in debug mode as temporary data exists: data/hash/488c8e0d5184748bf52bc26613bba9a5/reads/SS01011/r.proc.pangenomes99_v20.midas.d/SS01011/genes/SS01011.bam.idxstats
1709780150.4:  MIDAS2::bowtie2_align::finish
1709780150.4:  MIDAS2::prepare_species::start
1709780151.6:  MIDAS2::prepare_species::finish
1709780151.6:  MIDAS2::multiprocessing_map::start
Traceback (most recent call last):
  File "/pollard/home/bsmith/.snakemake/conda/04a7c23c60fb46956086919b7b0d6e28_/bin/midas2", line 33, in <module>
    sys.exit(load_entry_point('midas2', 'console_scripts', 'midas2')())
  File "/include/MIDAS2/midas2/__main__.py", line 25, in main
    return subcommand_main(subcommand_args)
  File "/include/MIDAS2/midas2/subcommands/run_genes.py", line 564, in main
    run_genes(args)
  File "/include/MIDAS2/midas2/subcommands/run_genes.py", line 558, in run_genes
    raise error
  File "/include/MIDAS2/midas2/subcommands/run_genes.py", line 525, in run_genes
    for chunk_start in range(0, total_c99_counts, chunk_size):
ValueError: range() arg 3 must not be zero
```

Looks like the edge case of `total_c99_counts` being 0 hasn't been handled.

Patched.